### PR TITLE
feat: support prompts for CLI and AWS Management Console

### DIFF
--- a/__tests__/components/PromptForm.test.tsx
+++ b/__tests__/components/PromptForm.test.tsx
@@ -223,6 +223,11 @@ describe("PromptForm component", () => {
       .setTextareaValue(
         "This is the prompt that will solve all my developer issues.",
       );
+
+    const interfaceTiles = wrapper.findTiles(
+      '[data-testid="tiles-interface"]',
+    )!;
+    interfaceTiles.findItemByValue("IDE")?.click();
     await waitFor(() =>
       wrapper.findButton('[data-testid="button-save"]')!.click(),
     );

--- a/__tests__/components/PromptForm.test.tsx
+++ b/__tests__/components/PromptForm.test.tsx
@@ -56,6 +56,11 @@ describe("PromptForm component", () => {
     expect(
       wrapper.findFormField('[data-testid="formfield-howto"]')!.getElement(),
     ).toBeInTheDocument();
+    expect(
+      wrapper
+        .findFormField('[data-testid="formfield-interface"]')!
+        .getElement(),
+    ).toBeInTheDocument();
   });
 
   it("renders input fields correctly", () => {
@@ -87,6 +92,9 @@ describe("PromptForm component", () => {
     ).toBeInTheDocument();
     expect(
       wrapper.findTextarea('[data-testid="textarea-howto"]')!.getElement(),
+    ).toBeInTheDocument();
+    expect(
+      wrapper.findTiles('[data-testid="tiles-interface"]')!.getElement(),
     ).toBeInTheDocument();
   });
 
@@ -171,6 +179,9 @@ describe("PromptForm component", () => {
         .findFormField('[data-testid="formfield-instruction"]')!
         .findError(),
     ).toBeTruthy();
+    expect(
+      wrapper.findFormField('[data-testid="formfield-interface"]')!.findError(),
+    ).toBeTruthy();
   });
 
   it("displays validation error", async () => {
@@ -228,6 +239,7 @@ describe("PromptForm component", () => {
       '[data-testid="tiles-interface"]',
     )!;
     interfaceTiles.findItemByValue("IDE")?.click();
+
     await waitFor(() =>
       wrapper.findButton('[data-testid="button-save"]')!.click(),
     );

--- a/__tests__/models/PromptViewModel.test.ts
+++ b/__tests__/models/PromptViewModel.test.ts
@@ -3,6 +3,7 @@ import {
   PromptViewModel,
   SdlcPhase,
   PromptCategory,
+  QInterface,
 } from "../../models/PromptViewModel";
 import { UserViewModel } from "../../models/UserViewModel";
 import { PromptFormInputs } from "@/components/PromptForm";
@@ -33,6 +34,7 @@ const schemaPrompt = {
   id: "1",
   name: "Test Prompt",
   description: "A test prompt",
+  interface: "IDE",
   sdlc_phase: "Design",
   category: "Chat",
   instruction: "Test instruction",
@@ -54,6 +56,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.description).toBe(schemaPrompt.description);
     expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.DESIGN);
     expect(promptViewModel.category).toBe(PromptCategory.CHAT);
+    expect(promptViewModel.interface).toBe(QInterface.IDE);
     expect(promptViewModel.instruction).toBe(schemaPrompt.instruction);
   });
 
@@ -138,6 +141,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.id).toBe(schemaPrompt.id);
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
+    expect(promptViewModel.interface).toBe(QInterface.UNKNOWN);
     expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.DESIGN);
     expect(promptViewModel.category).toBe(PromptCategory.CHAT);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);
@@ -163,6 +167,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.id).toBe(schemaPrompt.id);
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
+    expect(promptViewModel.interface).toBe(QInterface.IDE);
     expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.PLAN);
     expect(promptViewModel.category).toBe(PromptCategory.INLINE);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);
@@ -188,6 +193,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.id.startsWith("draft")).toBeTruthy();
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
+    expect(promptViewModel.interface).toBe(QInterface.UNKNOWN);
     expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.PLAN);
     expect(promptViewModel.category).toBe(PromptCategory.INLINE);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);

--- a/__tests__/models/PromptViewModel.test.ts
+++ b/__tests__/models/PromptViewModel.test.ts
@@ -110,6 +110,7 @@ describe("PromptViewModel", () => {
     const promptFormInputs: PromptFormInputs = {
       name: "Test Prompt",
       description: "A test prompt",
+      interface: "IDE",
       sdlc: "Design",
       category: "Chat",
       instruction: "Test instruction",
@@ -131,6 +132,7 @@ describe("PromptViewModel", () => {
     const promptFormInputs: PromptFormInputs = {
       name: "Test Prompt",
       description: "A test prompt",
+      interface: "IDE",
       sdlc: "Design",
       category: "Chat",
       instruction: "Test instruction",
@@ -141,7 +143,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.id).toBe(schemaPrompt.id);
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
-    expect(promptViewModel.interface).toBe(QInterface.UNKNOWN);
+    expect(promptViewModel.interface).toBe(QInterface.IDE);
     expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.DESIGN);
     expect(promptViewModel.category).toBe(PromptCategory.CHAT);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);
@@ -156,6 +158,7 @@ describe("PromptViewModel", () => {
     const promptFormInputs: PromptFormInputs = {
       name: "Updated",
       description: "Updated",
+      interface: "IDE",
       sdlc: "Plan",
       category: "Inline",
       instruction: "Updated",
@@ -182,6 +185,7 @@ describe("PromptViewModel", () => {
     const promptFormInputs: PromptFormInputs = {
       name: "Draft",
       description: "Draft",
+      interface: "CLI",
       sdlc: "Plan",
       category: "Inline",
       instruction: "Draft",
@@ -193,7 +197,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.id.startsWith("draft")).toBeTruthy();
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
-    expect(promptViewModel.interface).toBe(QInterface.UNKNOWN);
+    expect(promptViewModel.interface).toBe(QInterface.CLI);
     expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.PLAN);
     expect(promptViewModel.category).toBe(PromptCategory.INLINE);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);

--- a/__tests__/utils/formatters.test.ts
+++ b/__tests__/utils/formatters.test.ts
@@ -1,4 +1,11 @@
-import { createSelectOptions } from "@/utils/formatters";
+import {
+  createSelectOptions,
+  switchCategories,
+  IDEPromptCategory,
+  CLIPromptCategory,
+  ConsolePromptCateogry,
+} from "@/utils/formatters";
+import { QInterface, PromptCategory } from "@/models/PromptViewModel";
 import { describe, it, expect } from "vitest";
 
 enum TestPhases {
@@ -10,6 +17,40 @@ enum TestPhases {
   Deploy = "Deploy",
   Maintain = "Maintain",
 }
+
+describe("switchCategories", () => {
+  it("should return IDE categories when interface is IDE", () => {
+    const options = switchCategories(QInterface.IDE);
+    expect(options).toEqual(createSelectOptions(IDEPromptCategory));
+    expect(options.map((o) => o.value)).toEqual(
+      Object.values(IDEPromptCategory),
+    );
+  });
+
+  it("should return CLI categories when interface is CLI", () => {
+    const options = switchCategories(QInterface.CLI);
+    expect(options).toEqual(createSelectOptions(CLIPromptCategory));
+    expect(options.map((o) => o.value)).toEqual(
+      Object.values(CLIPromptCategory),
+    );
+  });
+
+  it("should return Console categories when interface is CONSOLE", () => {
+    const options = switchCategories(QInterface.CONSOLE);
+    expect(options).toEqual(createSelectOptions(ConsolePromptCateogry));
+    expect(options.map((o) => o.value)).toEqual(
+      Object.values(ConsolePromptCateogry),
+    );
+  });
+
+  it("should return filtered PromptCategory options for unknown interface", () => {
+    const options = switchCategories("unknown" as QInterface);
+    expect(options).toEqual(
+      createSelectOptions(PromptCategory, [PromptCategory.UNKNOWN]),
+    );
+    expect(options.map((o) => o.value)).not.toContain(PromptCategory.UNKNOWN);
+  });
+});
 
 describe("createSelectOptions", () => {
   it("should create select options from enum", () => {

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -6,6 +6,7 @@ const schema = a
       name: a.string().required(),
       description: a.string().required(),
       sdlc_phase: a.string().required(),
+      interface: a.string(),
       category: a.string().required(),
       instruction: a.string().required(),
       howto: a.string(),

--- a/components/Prompt.tsx
+++ b/components/Prompt.tsx
@@ -108,6 +108,7 @@ export default function Prompt(props: PromptProps) {
           </div>
           <SpaceBetween alignItems="start" direction="horizontal" size="xs">
             <Badge color="blue">{promptViewModel.sdlcPhase}</Badge>
+            <Badge color="green">{promptViewModel.interface}</Badge>
             <Badge color="grey">{promptViewModel.category}</Badge>
           </SpaceBetween>
         </SpaceBetween>

--- a/components/PromptCollection.tsx
+++ b/components/PromptCollection.tsx
@@ -108,6 +108,7 @@ export default function PromptCollection(props: PromptCollectionProps) {
             <SpaceBetween size="xs">
               <SpaceBetween size="xs" direction="horizontal">
                 <Badge color="blue">{item.sdlcPhase}</Badge>
+                <Badge color="green">{item.interface}</Badge>
                 <Badge color="grey">{item.category}</Badge>
               </SpaceBetween>
               <Link href={`/prompt/${item.id}`} fontSize="heading-s">

--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -34,6 +34,7 @@ interface PromptFormProps {
 export interface PromptFormInputs {
   name: string;
   description: string;
+  interface?: string;
   instruction: string;
   sdlc: string;
   category: string;
@@ -74,6 +75,7 @@ export default function PromptForm(props: PromptFormProps) {
     defaultValues: {
       name: props.prompt.name,
       description: props.prompt.description,
+      interface: props.prompt.interface,
       instruction: props.prompt.instruction,
       sdlc: props.prompt.sdlcPhase,
       category: props.prompt.category,

--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -11,6 +11,7 @@ import {
   Input,
   Textarea,
   Select,
+  Tiles,
 } from "@cloudscape-design/components";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -19,9 +20,10 @@ import * as yup from "yup";
 import {
   PromptCategory,
   PromptViewModel,
+  QInterface,
   SdlcPhase,
 } from "@/models/PromptViewModel";
-import { createSelectOptions } from "@/utils/formatters";
+import { createSelectOptions, createTilesItems } from "@/utils/formatters";
 import { useRouter } from "next/navigation";
 
 interface PromptFormProps {
@@ -47,6 +49,10 @@ const schema = yup
     description: yup.string().required().min(10).max(500),
     instruction: yup.string().required().min(10).max(4000),
     howto: yup.string().max(4000),
+    interface: yup
+      .string()
+      .required()
+      .matches(/^IDE|CLI|Management Console$/),
     sdlc: yup
       .string()
       .required()
@@ -62,7 +68,7 @@ const categoryOptions = createSelectOptions(PromptCategory, [
   PromptCategory.UNKNOWN,
 ]);
 const sdlcOptions = createSelectOptions(SdlcPhase, [SdlcPhase.UNKNOWN]);
-
+const interfaceTiles = createTilesItems(QInterface, [QInterface.UNKNOWN]);
 export default function PromptForm(props: PromptFormProps) {
   const {
     control,
@@ -204,6 +210,30 @@ export default function PromptForm(props: PromptFormProps) {
                       field.onChange(detail.selectedOption?.value)
                     }
                     options={sdlcOptions}
+                  />
+                )}
+              />
+            </FormField>
+            <FormField
+              data-testid="formfield-interface"
+              label="Amazon Q Developer Interface"
+              description="Is the prompt related to Amazon Q Developer in your IDE, your CLI or the AWS Management Console?"
+              stretch
+              errorText={errors.interface?.message}
+            >
+              <Controller
+                name="interface"
+                control={control}
+                render={({ field }) => (
+                  <Tiles
+                    {...field}
+                    data-testid="tiles-interface"
+                    value={
+                      interfaceTiles.find((opt) => opt.value === field.value)
+                        ?.value || ""
+                    }
+                    onChange={({ detail }) => field.onChange(detail.value)}
+                    items={interfaceTiles}
                   />
                 )}
               />

--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -13,17 +13,20 @@ import {
   Select,
   Tiles,
 } from "@cloudscape-design/components";
-import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import { Controller, SubmitHandler, useForm, useWatch } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
 import {
-  PromptCategory,
   PromptViewModel,
   QInterface,
   SdlcPhase,
 } from "@/models/PromptViewModel";
-import { createSelectOptions, createTilesItems } from "@/utils/formatters";
+import {
+  createSelectOptions,
+  createTilesItems,
+  switchCategories,
+} from "@/utils/formatters";
 import { useRouter } from "next/navigation";
 
 interface PromptFormProps {
@@ -60,15 +63,13 @@ const schema = yup
     category: yup
       .string()
       .required()
-      .matches(/^Chat|Dev Agent|Inline$/),
+      .matches(/^Chat|Dev Agent|Inline|Translate$/),
   })
   .required();
 
-const categoryOptions = createSelectOptions(PromptCategory, [
-  PromptCategory.UNKNOWN,
-]);
 const sdlcOptions = createSelectOptions(SdlcPhase, [SdlcPhase.UNKNOWN]);
 const interfaceTiles = createTilesItems(QInterface, [QInterface.UNKNOWN]);
+
 export default function PromptForm(props: PromptFormProps) {
   const {
     control,
@@ -89,6 +90,9 @@ export default function PromptForm(props: PromptFormProps) {
     },
   });
   const router = useRouter();
+
+  const qInterface = useWatch({ control, name: "interface" });
+  const categoryOptions = switchCategories(qInterface as QInterface);
 
   return (
     <form onSubmit={handleSubmit(props.onSubmit)} id="prompt-form">

--- a/models/PromptViewModel.ts
+++ b/models/PromptViewModel.ts
@@ -26,6 +26,13 @@ export enum PromptCategory {
   UNKNOWN = "Unknown",
 }
 
+export enum QInterface {
+  IDE = "IDE",
+  CLI = "CLI",
+  CONSOLE = "Management Console",
+  UNKNOWN = "Unknown",
+}
+
 export type ValidationError = { key: string; value: string };
 
 export type ValidationResult = {
@@ -37,6 +44,7 @@ export class PromptViewModel {
   private _id: string;
   private _name: string;
   private _description: string;
+  private _interface: QInterface;
   private _sdlcPhase: SdlcPhase;
   private _category: PromptCategory;
   private _instruction: string;
@@ -49,6 +57,7 @@ export class PromptViewModel {
     this._id = `draft_${uuidv4()}`;
     this._name = "Unnamed [DRAFT]";
     this._description = "";
+    this._interface = QInterface.UNKNOWN;
     this._sdlcPhase = SdlcPhase.UNKNOWN;
     this._category = PromptCategory.UNKNOWN;
     this._instruction = "";
@@ -65,6 +74,7 @@ export class PromptViewModel {
     pvm._id = prompt.id;
     pvm._name = prompt.name;
     pvm._description = prompt.description;
+    pvm._interface = (prompt.interface as QInterface) || QInterface.UNKNOWN;
     pvm._sdlcPhase = prompt.sdlc_phase as SdlcPhase;
     pvm._category = prompt.category as PromptCategory;
     pvm._instruction = prompt.instruction;
@@ -91,6 +101,13 @@ export class PromptViewModel {
   }
   public set description(value: string) {
     this._description = value;
+  }
+
+  public get interface(): QInterface {
+    return this._interface;
+  }
+  public set interface(value: QInterface) {
+    this._interface = value;
   }
 
   public get sdlcPhase(): SdlcPhase {

--- a/models/PromptViewModel.ts
+++ b/models/PromptViewModel.ts
@@ -23,6 +23,7 @@ export enum PromptCategory {
   CHAT = "Chat",
   DEV_AGENT = "Dev Agent",
   INLINE = "Inline",
+  TRANSLATE = "Translate",
   UNKNOWN = "Unknown",
 }
 

--- a/models/PromptViewModel.ts
+++ b/models/PromptViewModel.ts
@@ -161,6 +161,7 @@ export class PromptViewModel {
   ) {
     this._name = promptData.name;
     this._description = promptData.description;
+    this._interface = promptData.interface as QInterface;
     this._sdlcPhase = promptData.sdlc as SdlcPhase;
     this._category = promptData.category as PromptCategory;
     this._instruction = promptData.instruction;
@@ -188,6 +189,7 @@ export class PromptViewModel {
   saveDraft(promptData: PromptFormInputs, repository: DraftRepository) {
     this._name = promptData.name;
     this._description = promptData.description;
+    this._interface = promptData.interface as QInterface;
     this._sdlcPhase = promptData.sdlc as SdlcPhase;
     this._category = promptData.category as PromptCategory;
     this._instruction = promptData.instruction;

--- a/repositories/PromptRepository.ts
+++ b/repositories/PromptRepository.ts
@@ -34,6 +34,7 @@ export class PromptGraphQLRepository implements PromptRepository {
           id: prompt.id,
           name: prompt.name,
           description: prompt.description,
+          interface: prompt.interface,
           sdlc_phase: prompt.sdlcPhase,
           category: prompt.category,
           instruction: prompt.instruction,
@@ -55,6 +56,7 @@ export class PromptGraphQLRepository implements PromptRepository {
         {
           name: prompt.name,
           description: prompt.description,
+          interface: prompt.interface,
           sdlc_phase: prompt.sdlcPhase,
           category: prompt.category,
           instruction: prompt.instruction,

--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -1,4 +1,20 @@
+import { QInterface, PromptCategory } from "@/models/PromptViewModel";
 import { SelectProps, TilesProps } from "@cloudscape-design/components";
+
+export enum IDEPromptCategory {
+  CHAT = "Chat",
+  DEV_AGENT = "Dev Agent",
+  INLINE = "Inline",
+}
+
+export enum CLIPromptCategory {
+  CHAT = "Chat",
+  TRANSLATE = "Translate",
+}
+
+export enum ConsolePromptCateogry {
+  CHAT = "Chat",
+}
 
 export const createSelectOptions = <T extends string>(
   enumObject: { [key: string]: T },
@@ -30,6 +46,19 @@ export const createTilesItems = <T extends string>(
     }));
 
   return options;
+};
+
+export const switchCategories = (interfaceValue: QInterface) => {
+  switch (interfaceValue) {
+    case QInterface.IDE:
+      return createSelectOptions(IDEPromptCategory);
+    case QInterface.CLI:
+      return createSelectOptions(CLIPromptCategory);
+    case QInterface.CONSOLE:
+      return createSelectOptions(ConsolePromptCateogry);
+    default:
+      return createSelectOptions(PromptCategory, [PromptCategory.UNKNOWN]);
+  }
 };
 
 function getDescription(value: string): string {

--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -1,4 +1,4 @@
-import { SelectProps } from "@cloudscape-design/components";
+import { SelectProps, TilesProps } from "@cloudscape-design/components";
 
 export const createSelectOptions = <T extends string>(
   enumObject: { [key: string]: T },
@@ -16,7 +16,23 @@ export const createSelectOptions = <T extends string>(
   return options;
 };
 
-function getDescription(phase: string): string {
+export const createTilesItems = <T extends string>(
+  enumObject: { [key: string]: T },
+  excludeValues: T[] = [],
+): TilesProps.TilesDefinition[] => {
+  const options = Object.entries(enumObject)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .filter(([_, value]) => !excludeValues.includes(value))
+    .map(([, value]) => ({
+      label: value,
+      value: value,
+      description: getDescription(value),
+    }));
+
+  return options;
+};
+
+function getDescription(value: string): string {
   const descriptions: Record<string, string> = {
     Plan: "Define project scope, objectives, and feasibility while estimating resources and timelines.",
     Requirements:
@@ -30,6 +46,10 @@ function getDescription(phase: string): string {
       "Release the software to the production environment, including installation, configuration, and user training.",
     Maintain:
       "Monitor, update, and support the software post-deployment and addressing operational issues.",
+    IDE: "In IDEs, Amazon Q Developer includes capabilities to provide guidance and support across various aspects of software development, such as answering questions about building on AWS, generating and updating code, security scanning, and optimizing and refactoring code.",
+    CLI: "In the CLI, you can let Amazon Q Developer generate CLI commands, and automate tasks using natural language queries.",
+    "Management Console":
+      "In the AWS Management Console, you can ask Amazon Q Developer about your AWS resources and costs, contact AWS Support directly, and diagnose common console errors.",
   };
-  return descriptions[phase] || "";
+  return descriptions[value] || "";
 }


### PR DESCRIPTION
## Description
This pull requests adds support to create prompts for both the IDE, the AWS Management Console and the CLI. The new introduced attribute `interface` expresses the client interface a prompt is created for. Different interfaces have different capabilities. That's why the number of category options available is bound to the selected interface. 

## Related Issue

Fixes #49 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Regression Tests via Pull Requests
- [x] Unit tests triggered via Git hooks

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context
![image](https://github.com/user-attachments/assets/f5b2f47f-72ff-4f48-8d03-5b3a631ac005)
![Screenshot 2024-11-26 at 14 47 09](https://github.com/user-attachments/assets/19a881ca-9474-4e4f-a143-19950b2b1967)
![Screenshot 2024-11-26 at 14 47 25](https://github.com/user-attachments/assets/30809d2c-4b71-4ff1-a485-e1d633994c6f)
