### PR TITLE
feat: breakdown sdlc phases into activities

### DIFF
--- a/__tests__/components/PromptForm.test.tsx
+++ b/__tests__/components/PromptForm.test.tsx
@@ -169,9 +169,6 @@ describe("PromptForm component", () => {
         .findError(),
     ).toBeTruthy();
     expect(
-      wrapper.findFormField('[data-testid="formfield-sdlc"]')!.findError(),
-    ).toBeTruthy();
-    expect(
       wrapper.findFormField('[data-testid="formfield-category"]')!.findError(),
     ).toBeTruthy();
     expect(
@@ -292,5 +289,64 @@ describe("PromptForm component", () => {
       wrapper.findButton('[data-testid="button-cancel"]')!.click(),
     );
     expect(vi.mocked(backMock)).toHaveBeenCalled();
+  });
+
+  it("submits prompt with empty sdlc activity", async () => {
+    const { container } = render(
+      <PromptForm
+        prompt={new PromptViewModel()}
+        onSubmit={onSubmitMock}
+        onDelete={onDeleteMock}
+      />,
+    );
+    const wrapper = createWrapper(container);
+
+    wrapper
+      .findInput('[data-testid="input-name"]')!
+      .setInputValue("This is the name");
+    wrapper
+      .findInput('[data-testid="input-description"]')!
+      .setInputValue("This is the description");
+
+    wrapper
+      .findTextarea('[data-testid="textarea-instruction"]')!
+      .setTextareaValue(
+        "This is the prompt that will solve all my developer issues.",
+      );
+
+    const interfaceTiles = wrapper.findTiles(
+      '[data-testid="tiles-interface"]',
+    )!;
+    interfaceTiles.findItemByValue("IDE")?.click();
+
+    const categorySelect = wrapper.findSelect(
+      '[data-testid="select-category"]',
+    )!;
+    categorySelect.openDropdown();
+    categorySelect.selectOptionByValue("Chat");
+
+    await waitFor(() =>
+      wrapper.findButton('[data-testid="button-save"]')!.click(),
+    );
+    expect(vi.mocked(onSubmitMock)).toHaveBeenCalled();
+  });
+
+  it("not renders validation errors sdlc is empty", async () => {
+    const { container } = render(
+      <PromptForm
+        prompt={new PromptViewModel()}
+        onSubmit={onSubmitMock}
+        onDelete={onDeleteMock}
+      />,
+    );
+    const wrapper = createWrapper(container);
+
+    await waitFor(() => {
+      wrapper.findButton('[data-testid="button-save"]')!.click();
+    });
+
+    expect(
+      wrapper.findFormField('[data-testid="formfield-sdlc"]')!.findError(),
+    ).toBeFalsy();
   });
 });

--- a/__tests__/hooks/usePrompt.test.ts
+++ b/__tests__/hooks/usePrompt.test.ts
@@ -4,7 +4,7 @@ import { PromptGraphQLRepository } from "@/repositories/PromptRepository";
 import {
   PromptCategory,
   PromptViewModel,
-  SdlcPhase,
+  SdlcActivity,
 } from "@/models/PromptViewModel";
 import { usePrompt } from "@/hooks/usePrompt";
 

--- a/__tests__/models/PromptViewModel.test.ts
+++ b/__tests__/models/PromptViewModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   PromptViewModel,
-  SdlcPhase,
+  SdlcActivity,
   PromptCategory,
   QInterface,
 } from "../../models/PromptViewModel";
@@ -54,7 +54,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.id).toBe(schemaPrompt.id);
     expect(promptViewModel.name).toBe(schemaPrompt.name);
     expect(promptViewModel.description).toBe(schemaPrompt.description);
-    expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.DESIGN);
+    expect(promptViewModel.sdlcPhase).toBe(SdlcActivity.DESIGN);
     expect(promptViewModel.category).toBe(PromptCategory.CHAT);
     expect(promptViewModel.interface).toBe(QInterface.IDE);
     expect(promptViewModel.instruction).toBe(schemaPrompt.instruction);
@@ -144,7 +144,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
     expect(promptViewModel.interface).toBe(QInterface.IDE);
-    expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.DESIGN);
+    expect(promptViewModel.sdlcPhase).toBe(SdlcActivity.DESIGN);
     expect(promptViewModel.category).toBe(PromptCategory.CHAT);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);
     expect(promptViewModel.ownerUsername).toBe(user.preferredUsername);
@@ -171,7 +171,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
     expect(promptViewModel.interface).toBe(QInterface.IDE);
-    expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.PLAN);
+    expect(promptViewModel.sdlcPhase).toBe(SdlcActivity.PLAN);
     expect(promptViewModel.category).toBe(PromptCategory.INLINE);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);
     expect(promptViewModel.howto).toBe(promptFormInputs.howto);
@@ -198,7 +198,7 @@ describe("PromptViewModel", () => {
     expect(promptViewModel.name).toBe(promptFormInputs.name);
     expect(promptViewModel.description).toBe(promptFormInputs.description);
     expect(promptViewModel.interface).toBe(QInterface.CLI);
-    expect(promptViewModel.sdlcPhase).toBe(SdlcPhase.PLAN);
+    expect(promptViewModel.sdlcPhase).toBe(SdlcActivity.PLAN);
     expect(promptViewModel.category).toBe(PromptCategory.INLINE);
     expect(promptViewModel.instruction).toBe(promptFormInputs.instruction);
     expect(promptViewModel.howto).toBe(promptFormInputs.howto);

--- a/__tests__/utils/formatters.test.ts
+++ b/__tests__/utils/formatters.test.ts
@@ -5,18 +5,12 @@ import {
   CLIPromptCategory,
   ConsolePromptCateogry,
 } from "@/utils/formatters";
-import { QInterface, PromptCategory } from "@/models/PromptViewModel";
+import {
+  QInterface,
+  PromptCategory,
+  SdlcActivity,
+} from "@/models/PromptViewModel";
 import { describe, it, expect } from "vitest";
-
-enum TestPhases {
-  Plan = "Plan",
-  Requirements = "Requirements",
-  Design = "Design",
-  Implement = "Implement",
-  Test = "Test",
-  Deploy = "Deploy",
-  Maintain = "Maintain",
-}
 
 describe("switchCategories", () => {
   it("should return IDE categories when interface is IDE", () => {
@@ -54,39 +48,33 @@ describe("switchCategories", () => {
 
 describe("createSelectOptions", () => {
   it("should create select options from enum", () => {
-    const options = createSelectOptions(TestPhases);
+    const options = createSelectOptions(SdlcActivity);
 
-    expect(options).toHaveLength(7);
-    expect(options[0]).toEqual({
-      label: "Plan",
-      value: "Plan",
-      description:
-        "Define project scope, objectives, and feasibility while estimating resources and timelines.",
-    });
+    expect(options).toHaveLength(16);
   });
 
   it("should exclude specified values", () => {
-    const excludeValues = [TestPhases.Plan, TestPhases.Test];
-    const options = createSelectOptions(TestPhases, excludeValues);
+    const excludeValues = [SdlcActivity.PLAN, SdlcActivity.TEST];
+    const options = createSelectOptions(SdlcActivity, excludeValues);
 
-    expect(options).toHaveLength(5);
+    expect(options).toHaveLength(14);
     expect(options.some((opt) => opt.value === "Plan")).toBeFalsy();
     expect(options.some((opt) => opt.value === "Test")).toBeFalsy();
   });
 
   it("should handle empty exclude array", () => {
-    const options = createSelectOptions(TestPhases, []);
+    const options = createSelectOptions(SdlcActivity, []);
 
-    expect(options).toHaveLength(7);
+    expect(options).toHaveLength(16);
   });
 
   it("should include description for each option", () => {
-    const options = createSelectOptions(TestPhases);
+    const options = createSelectOptions(SdlcActivity);
 
     options.forEach((option) => {
       expect(option.description).toBeDefined();
       expect(typeof option.description).toBe("string");
-      expect(option.description!.length).toBeGreaterThan(0);
+      expect(option.description).not.toBeUndefined();
     });
   });
 });

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -5,7 +5,7 @@ const schema = a
       id: a.id().required(),
       name: a.string().required(),
       description: a.string().required(),
-      sdlc_phase: a.string().required(),
+      sdlc_phase: a.string(),
       interface: a.string(),
       category: a.string().required(),
       instruction: a.string().required(),

--- a/components/Prompt.tsx
+++ b/components/Prompt.tsx
@@ -107,7 +107,9 @@ export default function Prompt(props: PromptProps) {
             <pre className="wrap">{promptViewModel.instruction}</pre>
           </div>
           <SpaceBetween alignItems="start" direction="horizontal" size="xs">
-            <Badge color="blue">{promptViewModel.sdlcPhase}</Badge>
+            {promptViewModel.hasSDLCPhaseAssigned() && (
+              <Badge color="blue">{promptViewModel.sdlcPhase}</Badge>
+            )}
             <Badge color="green">{promptViewModel.interface}</Badge>
             <Badge color="grey">{promptViewModel.category}</Badge>
           </SpaceBetween>

--- a/components/PromptCollection.tsx
+++ b/components/PromptCollection.tsx
@@ -107,7 +107,9 @@ export default function PromptCollection(props: PromptCollectionProps) {
           header: (item) => (
             <SpaceBetween size="xs">
               <SpaceBetween size="xs" direction="horizontal">
-                <Badge color="blue">{item.sdlcPhase}</Badge>
+                {item.hasSDLCPhaseAssigned() && (
+                  <Badge color="blue">{item.sdlcPhase}</Badge>
+                )}
                 <Badge color="green">{item.interface}</Badge>
                 <Badge color="grey">{item.category}</Badge>
               </SpaceBetween>

--- a/components/PromptCollection.tsx
+++ b/components/PromptCollection.tsx
@@ -20,7 +20,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { usePromptCollection } from "../hooks/usePromptCollection";
 import { Facets } from "@/repositories/PromptRepository";
 import { useState } from "react";
-import { PromptCategory, SdlcPhase } from "@/models/PromptViewModel";
+import { PromptCategory, SdlcActivity } from "@/models/PromptViewModel";
 import { createSelectOptions } from "@/utils/formatters";
 
 interface PromptCollectionProps {
@@ -58,7 +58,7 @@ export default function PromptCollection(props: PromptCollectionProps) {
   };
 
   const getSDLCFilter = () => {
-    return createSelectOptions(SdlcPhase, [SdlcPhase.UNKNOWN]);
+    return createSelectOptions(SdlcActivity, [SdlcActivity.UNKNOWN]);
   };
 
   const handleCategoryFilterChange = (option: SelectProps.Option) => {

--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -20,7 +20,7 @@ import * as yup from "yup";
 import {
   PromptViewModel,
   QInterface,
-  SdlcPhase,
+  SdlcActivity,
 } from "@/models/PromptViewModel";
 import {
   createSelectOptions,
@@ -68,7 +68,7 @@ const schema = yup
   })
   .required();
 
-const sdlcOptions = createSelectOptions(SdlcPhase, [SdlcPhase.UNKNOWN]);
+const sdlcOptions = createSelectOptions(SdlcActivity, [SdlcActivity.UNKNOWN]);
 const interfaceTiles = createTilesItems(QInterface, [QInterface.UNKNOWN]);
 
 export default function PromptForm(props: PromptFormProps) {

--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -41,8 +41,8 @@ export interface PromptFormInputs {
   description: string;
   interface?: string;
   instruction: string;
-  sdlc: string;
-  category: string;
+  sdlc?: string;
+  category?: string;
   howto?: string;
 }
 
@@ -58,8 +58,9 @@ const schema = yup
       .matches(/^IDE|CLI|Management Console$/),
     sdlc: yup
       .string()
-      .required()
-      .matches(/^Plan|Requirements|Design|Implement|Test|Deploy|Maintain$/),
+      .matches(
+        /^Plan|Requirements|Design|Implement|Test|Deploy|Maintain|Unknown$/,
+      ),
     category: yup
       .string()
       .required()
@@ -195,8 +196,13 @@ export default function PromptForm(props: PromptFormProps) {
             </FormField>
             <FormField
               data-testid="formfield-sdlc"
-              label="Software Development Lifecycle (SDLC) Phase"
-              description="Which phase of the SDLC does this prompt relate to?"
+              label={
+                <span>
+                  Software Development Lifecycle (SDLC) Activity{" "}
+                  <i>- optional</i>
+                </span>
+              }
+              description="Which activity of the SDLC does this prompt relate to?"
               stretch
               errorText={errors.sdlc?.message}
             >

--- a/models/PromptViewModel.ts
+++ b/models/PromptViewModel.ts
@@ -8,14 +8,22 @@ import {
 } from "@/repositories/PromptRepository";
 import { DraftRepository } from "@/repositories/DraftRepository";
 
-export enum SdlcPhase {
-  PLAN = "Plan",
-  REQ = "Requirements",
-  DESIGN = "Design",
-  IMPLEMENT = "Implement",
-  TEST = "Test",
+export enum SdlcActivity {
+  DEBUG = "Debugging",
   DEPLOY = "Deploy",
-  MAINTAIN = "Maintain",
+  DESIGN = "Design",
+  DOCUMENT = "Documentation",
+  ENHANCE = "Enhance",
+  IMPLEMENT = "Implement",
+  OPERATE = "Operate",
+  OPTIMIZE = "Optimize",
+  PATCH = "Patch Management",
+  PLAN = "Plan",
+  REFACTOR = "Refactoring",
+  REQ = "Requirements",
+  SECURITY = "Security",
+  SUPPORT = "Support",
+  TEST = "Test",
   UNKNOWN = "Unknown",
 }
 
@@ -46,7 +54,7 @@ export class PromptViewModel {
   private _name: string;
   private _description: string;
   private _interface: QInterface;
-  private _sdlcPhase: SdlcPhase;
+  private _sdlcPhase: SdlcActivity;
   private _category: PromptCategory;
   private _instruction: string;
   private _howto: string;
@@ -59,7 +67,7 @@ export class PromptViewModel {
     this._name = "Unnamed [DRAFT]";
     this._description = "";
     this._interface = QInterface.UNKNOWN;
-    this._sdlcPhase = SdlcPhase.UNKNOWN;
+    this._sdlcPhase = SdlcActivity.UNKNOWN;
     this._category = PromptCategory.UNKNOWN;
     this._instruction = "";
     this._howto = "";
@@ -76,7 +84,7 @@ export class PromptViewModel {
     pvm._name = prompt.name;
     pvm._description = prompt.description;
     pvm._interface = (prompt.interface as QInterface) || QInterface.UNKNOWN;
-    pvm._sdlcPhase = prompt.sdlc_phase as SdlcPhase;
+    pvm._sdlcPhase = prompt.sdlc_phase as SdlcActivity;
     pvm._category = prompt.category as PromptCategory;
     pvm._instruction = prompt.instruction;
     pvm._owner = prompt.owner;
@@ -111,10 +119,10 @@ export class PromptViewModel {
     this._interface = value;
   }
 
-  public get sdlcPhase(): SdlcPhase {
+  public get sdlcPhase(): SdlcActivity {
     return this._sdlcPhase;
   }
-  public set sdlcPhase(value: SdlcPhase) {
+  public set sdlcPhase(value: SdlcActivity) {
     this._sdlcPhase = value;
   }
 
@@ -163,7 +171,7 @@ export class PromptViewModel {
     this._name = promptData.name;
     this._description = promptData.description;
     this._interface = promptData.interface as QInterface;
-    this._sdlcPhase = promptData.sdlc as SdlcPhase;
+    this._sdlcPhase = promptData.sdlc as SdlcActivity;
     this._category = promptData.category as PromptCategory;
     this._instruction = promptData.instruction;
     this._howto = promptData.howto || "";
@@ -191,7 +199,7 @@ export class PromptViewModel {
     this._name = promptData.name;
     this._description = promptData.description;
     this._interface = promptData.interface as QInterface;
-    this._sdlcPhase = promptData.sdlc as SdlcPhase;
+    this._sdlcPhase = promptData.sdlc as SdlcActivity;
     this._category = promptData.category as PromptCategory;
     this._instruction = promptData.instruction;
     this._howto = promptData.howto || "";
@@ -204,6 +212,6 @@ export class PromptViewModel {
   }
 
   public hasSDLCPhaseAssigned() {
-    return this._sdlcPhase !== SdlcPhase.UNKNOWN;
+    return this._sdlcPhase !== SdlcActivity.UNKNOWN;
   }
 }

--- a/models/PromptViewModel.ts
+++ b/models/PromptViewModel.ts
@@ -202,4 +202,8 @@ export class PromptViewModel {
   public isDraft() {
     return this._draft;
   }
+
+  public hasSDLCPhaseAssigned() {
+    return this._sdlcPhase !== SdlcPhase.UNKNOWN;
+  }
 }

--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -69,12 +69,30 @@ function getDescription(value: string): string {
     Design:
       "Create the software architecture, user interface, and system design based on the requirements.",
     Implement:
-      "Write, refactor, fix and review the actual code for the software according to design specifications.",
-    Test: "Conduct various types of testing to identify and fix bugs, ensuring the software meets quality standards and requirements.",
+      "Write and review code according to design specifications and coding standards.",
+    Test: "Conduct various types of testing to identify and fix bugs, ensuring software meets quality standards.",
     Deploy:
-      "Release the software to the production environment, including installation, configuration, and user training.",
-    Maintain:
-      "Monitor, update, and support the software post-deployment and addressing operational issues.",
+      "Release software to production, including installation, configuration, and user training.",
+    Operate:
+      "Manage day-to-day running of systems, including monitoring, maintenance, and incident response.",
+    Optimize:
+      "Improve system performance, efficiency, and cost-effectiveness through analysis and tuning.",
+    Support:
+      "Provide technical assistance, troubleshoot issues, and resolve user inquiries.",
+    Enhance:
+      "Add new features or improve existing functionality based on user feedback and business needs.",
+    Documentation:
+      "Create and maintain technical, user, and process documentation for the software system.",
+    Refactoring:
+      "Restructure and improve existing code without changing its external behavior.",
+    Debugging:
+      "Identify, analyze, and fix software defects and issues in the codebase.",
+    Security:
+      "Implement security measures, conduct assessments, and address vulnerabilities.",
+    "Patch Management":
+      "Plan, test, and deploy software updates, security fixes, and system patches across your infrastructure and applications.",
+
+    Unknown: "",
     IDE: "In IDEs, Amazon Q Developer includes capabilities to provide guidance and support across various aspects of software development, such as answering questions about building on AWS, generating and updating code, security scanning, and optimizing and refactoring code.",
     CLI: "In the CLI, you can let Amazon Q Developer generate CLI commands, and automate tasks using natural language queries.",
     "Management Console":


### PR DESCRIPTION
## Description

This PR breaks down the SDLC phases into more granular activities to give users better options. With more options and renaming the field to SDLC Activity, I decided to make the attribute optional. Users should not be forced to make a decision when submitting a prompt but can add this information later if it provides a better discoverability. 

## Related Issue

Fixes #58 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Updated unit tests
- [ ] Manual regression test in sandbox environment

## Checklist:

Before submitting your pull request, please review the following checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
<img width="1018" alt="Screenshot 2024-11-26 at 23 24 57" src="https://github.com/user-attachments/assets/de210fe1-46cd-4fcc-a38e-58ad28375d59">

<img width="1009" alt="Screenshot 2024-11-26 at 23 25 38" src="https://github.com/user-attachments/assets/ca4f6f99-53cc-486b-a44f-e5c79d08c82f">

<img width="1453" alt="Screenshot 2024-11-26 at 23 20 27" src="https://github.com/user-attachments/assets/2aa75d2c-1f9c-4df0-bdfd-62bd212c3f46">

