### PR TITLE
fix: select new SDLC activities in prompt form

### DIFF
--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -213,6 +213,7 @@ export default function PromptForm(props: PromptFormProps) {
                   <Select
                     {...field}
                     data-testid="select-sdlc"
+                    filteringType="auto"
                     selectedOption={
                       sdlcOptions.find((opt) => opt.value === field.value)!
                     }

--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -59,7 +59,7 @@ const schema = yup
     sdlc: yup
       .string()
       .matches(
-        /^Plan|Requirements|Design|Implement|Test|Deploy|Maintain|Unknown$/,
+        /^Debugging|Deploy|Design|Documentation|Enhance|Implement|Operate|Optimize|Patch Management|Plan|Refactoring|Requirements|Security|Support|Test|Unknown$/,
       ),
     category: yup
       .string()


### PR DESCRIPTION
## Description

Fixes an issue that does not allow to select new added SDLC activities in the prompt form. 

## Related Issue

Fixes #(issue number)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual regression test

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context or screenshots about the pull request here.
