### PR TITLE
style: move optional form fields to the bottom of the form

### DIFF
--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -195,37 +195,6 @@ export default function PromptForm(props: PromptFormProps) {
               />
             </FormField>
             <FormField
-              data-testid="formfield-sdlc"
-              label={
-                <span>
-                  Software Development Lifecycle (SDLC) Activity{" "}
-                  <i>- optional</i>
-                </span>
-              }
-              description="Which activity of the SDLC does this prompt relate to?"
-              stretch
-              errorText={errors.sdlc?.message}
-            >
-              <Controller
-                name="sdlc"
-                control={control}
-                render={({ field }) => (
-                  <Select
-                    {...field}
-                    data-testid="select-sdlc"
-                    filteringType="auto"
-                    selectedOption={
-                      sdlcOptions.find((opt) => opt.value === field.value)!
-                    }
-                    onChange={({ detail }) =>
-                      field.onChange(detail.selectedOption?.value)
-                    }
-                    options={sdlcOptions}
-                  />
-                )}
-              />
-            </FormField>
-            <FormField
               data-testid="formfield-interface"
               label="Amazon Q Developer Interface"
               description="Is the prompt related to Amazon Q Developer in your IDE, your CLI or the AWS Management Console?"
@@ -275,6 +244,27 @@ export default function PromptForm(props: PromptFormProps) {
               />
             </FormField>
             <FormField
+              data-testid="formfield-instruction"
+              label="Instruction"
+              description="The specific task you want Amazon Q Developer to perform."
+              stretch
+              errorText={errors.instruction?.message}
+            >
+              <Controller
+                name="instruction"
+                control={control}
+                render={({ field }) => (
+                  <Textarea
+                    {...field}
+                    data-testid="textarea-instruction"
+                    rows={10}
+                    value={field.value}
+                    onChange={({ detail }) => field.onChange(detail.value)}
+                  />
+                )}
+              />
+            </FormField>
+            <FormField
               data-testid="formfield-howto"
               label={
                 <span>
@@ -300,22 +290,32 @@ export default function PromptForm(props: PromptFormProps) {
               />
             </FormField>
             <FormField
-              data-testid="formfield-instruction"
-              label="Instruction"
-              description="The specific task you want Amazon Q Developer to perform."
+              data-testid="formfield-sdlc"
+              label={
+                <span>
+                  Software Development Lifecycle (SDLC) Activity{" "}
+                  <i>- optional</i>
+                </span>
+              }
+              description="Which activity of the SDLC does this prompt relate to?"
               stretch
-              errorText={errors.instruction?.message}
+              errorText={errors.sdlc?.message}
             >
               <Controller
-                name="instruction"
+                name="sdlc"
                 control={control}
                 render={({ field }) => (
-                  <Textarea
+                  <Select
                     {...field}
-                    data-testid="textarea-instruction"
-                    rows={10}
-                    value={field.value}
-                    onChange={({ detail }) => field.onChange(detail.value)}
+                    data-testid="select-sdlc"
+                    filteringType="auto"
+                    selectedOption={
+                      sdlcOptions.find((opt) => opt.value === field.value)!
+                    }
+                    onChange={({ detail }) =>
+                      field.onChange(detail.selectedOption?.value)
+                    }
+                    options={sdlcOptions}
                   />
                 )}
               />


### PR DESCRIPTION
## Description

Moves optional form fields in prompt form to the bottom to increase the focus on editing mandatory fields first. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Manual regression test

## Checklist:

Before submitting your pull request, please review the following checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context or screenshots about the pull request here.
