### PR TITLE
style: rename formfield label for instruction to prompt

### DIFF
--- a/components/PromptForm.tsx
+++ b/components/PromptForm.tsx
@@ -245,8 +245,8 @@ export default function PromptForm(props: PromptFormProps) {
             </FormField>
             <FormField
               data-testid="formfield-instruction"
-              label="Instruction"
-              description="The specific task you want Amazon Q Developer to perform."
+              label="Prompt"
+              description="What is the prompt? What is the specific task you want Amazon Q Developer to perform?"
               stretch
               errorText={errors.instruction?.message}
             >


### PR DESCRIPTION
## Description

The field named "instruction" is where users should enter the prompt. That is confusing. Let's keep it simple and stick with the ubiquitous language and name it just "prompt". The Appsync data model must be untouched to be backward compatible.


## Related Issue

Fixes #64 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual regression test

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

Add any other context or screenshots about the pull request here.
