### PR TITLE
feat: prompts in prompt page display scrollable content

### DIFF
--- a/components/prompt/prompt-instruction.tsx
+++ b/components/prompt/prompt-instruction.tsx
@@ -2,6 +2,7 @@ import { ModelType } from "@/lib/forms/schema-definitions";
 import CopyClipBoardButton from "@/components/common/copy-clipboard";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { LucideIcon } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface PromptInstructionProps {
   promptId: string;
@@ -31,7 +32,9 @@ export default function PromptInstruction({
         />
       </CardHeader>
       <CardContent>
-        <pre className="text-gray-400">{text}</pre>
+        <ScrollArea className="h-96">
+          <pre className="text-gray-400">{text}</pre>
+        </ScrollArea>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Description

Prompt content displays in a scrollable container with a fixed height, similar to how project rules handle long content. This makes longer prompts more readable and provide a consistent user experience across the platform.

Existing component "ScrollArea" like in component "ProjectRuleDetail"

## Related Issue

Fixes #112

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

No rendering test was coded. I checked the functionality by creating a long prompt and check the content was scrollable

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Before:
<img width="815" height="742" alt="image" src="https://github.com/user-attachments/assets/b6695253-7507-4e9d-a435-b6cd453acbb2" />


After:
<img width="1515" height="821" alt="image" src="https://github.com/user-attachments/assets/aa087a2f-6ec8-4429-8fe2-0ccbc84ecf19" />

