### PR TITLE
feat: add download functionality for prompts to achieve feature parity with project rules

### DIFF
--- a/__tests__/components/prompt/prompt-card.test.tsx
+++ b/__tests__/components/prompt/prompt-card.test.tsx
@@ -48,6 +48,17 @@ describe("PromptCard", () => {
     );
   });
 
+  test("Shows download count when downloadCount is greater than 0", () => {
+    const promptWithDownloads = { ...basePrompt, downloadCount: 25 };
+    render(<PromptCard prompt={promptWithDownloads} />);
+
+    expect(screen.getByText("25 downloads")).toBeInTheDocument();
+    expect(screen.getByText("25 downloads").closest("div")).toHaveClass(
+      "flex",
+      "items-center",
+    );
+  });
+
   test("Shows copy count even when copyCount is 0", () => {
     const promptWithZeroCopies = { ...basePrompt, copyCount: 0 };
     render(<PromptCard prompt={promptWithZeroCopies} />);
@@ -57,6 +68,17 @@ describe("PromptCard", () => {
     // The copy icon should be present - check by looking for the SVG with the lucide-copy class
     const copyIcon = document.querySelector(".lucide-copy");
     expect(copyIcon).toBeInTheDocument();
+  });
+
+  test("Shows download count even when downloadCount is 0", () => {
+    const promptWithZeroDownload = { ...basePrompt, downloadCount: 0 };
+    render(<PromptCard prompt={promptWithZeroDownload} />);
+
+    // Should show download count even when it's 0
+    expect(screen.getByText("0 downloads")).toBeInTheDocument();
+    // The download icon should be present - check by looking for the SVG with the lucide-download class
+    const downloadIcon = document.querySelector(".lucide-download");
+    expect(downloadIcon).toBeInTheDocument();
   });
 
   test("Shows 'Trending' badge for prompts with 50-99 copies", () => {
@@ -147,5 +169,17 @@ describe("PromptCard", () => {
     expect(screen.queryByText(/times copied/)).not.toBeInTheDocument();
     const copyIcon = document.querySelector(".lucide-copy");
     expect(copyIcon).not.toBeInTheDocument();
+  });
+
+  test("Does not show download count when download Count is undefined", () => {
+    const promptWithoutDownloadCount = {
+      ...basePrompt,
+      downloadCount: undefined,
+    };
+    render(<PromptCard prompt={promptWithoutDownloadCount} />);
+
+    expect(screen.queryByText(/downloads/)).not.toBeInTheDocument();
+    const downloadIcon = document.querySelector(".lucide-download");
+    expect(downloadIcon).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/prompt/prompt-detail.test.tsx
+++ b/__tests__/components/prompt/prompt-detail.test.tsx
@@ -67,6 +67,14 @@ jest.mock("@/components/common/edit-button", () => {
   };
 });
 
+jest.mock("@/components/common/download-button", () => {
+  return {
+    DownloadButton: function DownloadButton() {
+      return <div data-testid="download-button">Download Button</div>;
+    },
+  };
+});
+
 jest.mock("@/components/common/source-url", () => {
   return {
     SourceURL: function SourceURL() {
@@ -141,9 +149,10 @@ describe("PromptDetail", () => {
     expect(screen.getByTestId("prompt-instruction")).toBeInTheDocument();
     expect(screen.getByTestId("prompt-howto")).toBeInTheDocument();
 
-    // Check if edit and copy buttons are rendered
+    // Check if edit, copy and download buttons are rendered
     expect(screen.getByTestId("edit-button")).toBeInTheDocument();
     expect(screen.getByTestId("copy-button")).toBeInTheDocument();
+    expect(screen.getByTestId("download-button")).toBeInTheDocument();
 
     // Check if source URL is rendered
     expect(screen.getByTestId("source-url")).toBeInTheDocument();

--- a/components/prompt/prompt-card.tsx
+++ b/components/prompt/prompt-card.tsx
@@ -1,7 +1,7 @@
 import { Prompt } from "@/lib/models/prompt-model";
 import Author from "@/components/common/author";
 import Tags from "@/components/common/tags";
-import { Flame, Copy } from "lucide-react";
+import { Flame, Copy, Download } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -58,12 +58,20 @@ export default function PromptCard({ prompt }: PromptCardProps) {
         </CardContent>
         <CardFooter className="flex justify-between items-center">
           {prompt.author && <Author name={prompt.author} />}
-          {prompt.copyCount !== undefined && (
-            <div className="flex items-center text-muted-foreground text-sm">
-              <Copy className="w-4 h-4 mr-1" />
-              <span>{prompt.copyCount.toLocaleString()} times copied</span>
-            </div>
-          )}
+          <div className="flex items-center gap-4 text-muted-foreground text-sm">
+            {prompt.copyCount !== undefined && (
+              <div className="flex items-center">
+                <Copy className="w-4 h-4 mr-1" />
+                <span>{prompt.copyCount.toLocaleString()} times copied</span>
+              </div>
+            )}
+            {prompt.downloadCount !== undefined && (
+              <div className="flex items-center">
+                <Download className="w-4 h-4 mr-1" />
+                <span>{prompt.downloadCount.toLocaleString()} downloads</span>
+              </div>
+            )}
+          </div>
         </CardFooter>
       </Card>
     </Link>

--- a/components/prompt/prompt-detail.tsx
+++ b/components/prompt/prompt-detail.tsx
@@ -8,6 +8,7 @@ import PromptHowTo from "@/components/prompt/prompt-howto";
 import EditButton from "@/components/common/edit-button";
 import { Prompt } from "@/lib/models/prompt-model";
 import Submission from "@/components/common/submission";
+import { DownloadButton } from "@/components/common/download-button";
 
 interface PromptProps {
   prompt: Prompt;
@@ -48,11 +49,20 @@ export default async function PromptDetail(props: PromptProps) {
                 />
               )}
               {props.prompt.content && (
-                <CopyClipBoardButton
-                  id={props.prompt.id!}
-                  type={ModelType.PROMPT}
-                  text={props.prompt.content}
-                />
+                <>
+                  <CopyClipBoardButton
+                    id={props.prompt.id!}
+                    type={ModelType.PROMPT}
+                    text={props.prompt.content}
+                  />
+                  <DownloadButton
+                    id={props.prompt.id!}
+                    content={props.prompt.content}
+                    filename={`promptz-prompts-${props.prompt.slug}`}
+                    label="Download"
+                    modelType={ModelType.PROMPT}
+                  />
+                </>
               )}
             </div>
           </div>

--- a/components/prompt/prompt-detail.tsx
+++ b/components/prompt/prompt-detail.tsx
@@ -58,7 +58,7 @@ export default async function PromptDetail(props: PromptProps) {
                   <DownloadButton
                     id={props.prompt.id!}
                     content={props.prompt.content}
-                    filename={`promptz-prompts-${props.prompt.slug}`}
+                    filename={`promptz-prompt-${props.prompt.slug}`}
                     label="Download"
                     modelType={ModelType.PROMPT}
                   />

--- a/lib/actions/fetch-prompts-action.ts
+++ b/lib/actions/fetch-prompts-action.ts
@@ -19,6 +19,8 @@ interface PromptBySlugResponse {
       sourceURL?: string;
       howto?: string;
       scope?: string;
+      copyCount?: number;
+      downloadCount?: number;
       author: {
         id?: string;
         displayName?: string;
@@ -49,6 +51,8 @@ export async function fetchPromptBySlug(slug: string) {
         sourceURL
         howto
         scope
+        copyCount
+        downloadCount
         author {
           id
           displayName
@@ -89,6 +93,8 @@ export async function fetchPromptBySlug(slug: string) {
     sourceURL: prompt.sourceURL,
     howto: prompt.howto,
     scope: prompt.scope,
+    copyCount: prompt.copyCount,
+    downloadCount: prompt.downloadCount,
     author: prompt.author ? prompt.author.displayName : "",
     authorId: prompt.author ? prompt.author.id : "",
     createdAt: prompt.createdAt,

--- a/lib/actions/search-prompts-action.ts
+++ b/lib/actions/search-prompts-action.ts
@@ -60,6 +60,7 @@ export async function searchPrompts(
           createdAt: p.createdAt || "",
           updatedAt: p.updatedAt || "",
           copyCount: p.copyCount || 0,
+          downloadCount: p.downloadCount || 0,
         } as Prompt;
       });
 


### PR DESCRIPTION
## Description

Context : 
Users currently experience inconsistent functionality between prompts and project rules on the promptz.dev platform. Project rules have both "Copy" and "Download" options available, while prompts only have a "Copy" option. This creates a confusing user experience and limits the utility of prompts for users who want to save them locally for offline use or integration into their local prompt libraries.

- Add already existing component "DownloadButton" to prompt-detail.tsx
- Add copyCount and downloadCount to fetch-prompts-action.ts for them to be available un prompt page
- Add downloadCount to search-prompts-action.ts, add downloadCount in prompt listing

## Related Issue

Fixes #110 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Add download button rendering test in already existing prompt-detail.test.tsx
- [x] Add download count rendering test in already existing projet-card.test.tsx

I was able to test everything but large download counts. The same test for copy counts already fails on my machine :

```javascript
// prompt-card.test.tsx
 test("Formats large copy counts with locale string", () => {
    const popularPrompt = { ...basePrompt, copyCount: 1234 };
    render(<PromptCard prompt={popularPrompt} />);

    // Check that the number is formatted (could be "1,234" or "1.234" depending on locale)
    const formattedNumber = (1234).toLocaleString();
    expect(
      screen.getByText(`${formattedNumber} times copied`),
    ).toBeInTheDocument();
  });
```
```javascript
// test result 
                    <path
                      d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
                    />
                  </svg>
                  <span>
                    1 234
                     times copied
                  </span>
                </div>
              </div>
            </div>
          </div>
        </a>
      </div>
    </body>

      114 |     const formattedNumber = (1234).toLocaleString();
      115 |     expect(
    > 116 |       screen.getByText(`${formattedNumber} times copied`),
          |              ^
      117 |     ).toBeInTheDocument();
      118 |   });
      119 |
```

I tried frew things to adapt the test but I was not able to find a solution. Any idea ? Should I write an issue ?


## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

While working on this issue, I found several differences between project rules and prompts. I will write an issue with details.
I tried my best to give meaning full commit messages. If this part can be improved, please tell me.
