### PR TITLE
feat: remove copy prompt fonctionality in prompt-instruction

### DIFF
--- a/__tests__/components/prompt/prompt-instruction.test.tsx
+++ b/__tests__/components/prompt/prompt-instruction.test.tsx
@@ -6,7 +6,6 @@ import { Terminal } from "lucide-react";
 
 describe("PromptInstruction", () => {
   const defaultProps = {
-    promptId: "test-prompt-id",
     title: "Test Prompt Title",
     text: "This is a test prompt instruction text",
     icon: Terminal,

--- a/components/agents/agent-detail.tsx
+++ b/components/agents/agent-detail.tsx
@@ -111,7 +111,6 @@ export default function AgentDetail(props: AgentProps) {
         >
           <PromptInstruction
             title="System Prompt"
-            promptId={props.agent.id!}
             icon={Terminal}
             text={props.agent.prompt!}
           />

--- a/components/prompt/prompt-detail.tsx
+++ b/components/prompt/prompt-detail.tsx
@@ -110,7 +110,6 @@ export default async function PromptDetail(props: PromptProps) {
         >
           <PromptInstruction
             title="Prompt"
-            promptId={props.prompt.id!}
             icon={Terminal}
             text={props.prompt.content!}
           />

--- a/components/prompt/prompt-instruction.tsx
+++ b/components/prompt/prompt-instruction.tsx
@@ -2,14 +2,12 @@ import { LucideIcon } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface PromptInstructionProps {
-  promptId: string;
   title: string;
   text: string;
   icon: LucideIcon;
 }
 
 export default function PromptInstruction({
-  promptId,
   title,
   text,
   icon: Icon,


### PR DESCRIPTION
## Description

In the Prompt page, the “Copy Prompt” button in the prompt instruction area was removed. The goal is to improve parity between prompt page and projet rule page.

- Remove CopyClopBoardButton from prompt-instruction.tsx
- Refactor code structure in prompt-instruction to mimic project-rule-detail.tsx
- Remove related test in prompt-instruction.test.tsx

## Related Issue

Fixes #122 

## Type of change

- [x] Remove functionality

## How Has This Been Tested?

- [x] tested by removing rendering of the copy prompt component

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

With copy prompt:
<img width="1605" height="736" alt="image" src="https://github.com/user-attachments/assets/2be781f1-d598-46f0-a9f0-e7bca512bfac" />

Without copy prompt:
<img width="1590" height="715" alt="image" src="https://github.com/user-attachments/assets/627664be-5d07-428f-9c00-ccca6dec0268" />

