### PR TITLE
fix: fetch for download count and copy count in my-prompts-action.ts

### DIFF
--- a/lib/actions/my-prompts-action.ts
+++ b/lib/actions/my-prompts-action.ts
@@ -38,6 +38,8 @@ export async function fetchMyPrompts(userId: string): Promise<Prompt[]> {
       description: p.description,
       author: data.displayName || "",
       authorId: p.owner || "",
+      copyCount: p.copyCount || 0,
+      downloadCount: p.downloadCount || 0,
       tags: (p.tags || []).filter((tag): tag is string => tag !== null),
       slug: p.slug || "",
       content: p.content,


### PR DESCRIPTION


## Description

This addition allow MyPrompts page to display download and copy counts

## Related Issue

No issue related

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No test was written

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Before :
![Capture d’écran 2025-09-04 141400](https://github.com/user-attachments/assets/6f9db926-6fb3-4573-b862-4cc26d6d5c61)
After :
![Capture d’écran 2025-09-04 141712](https://github.com/user-attachments/assets/5fd49cad-3ba7-46ae-87aa-b3ce2b529860)

